### PR TITLE
Add Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: java
+jdk: oraclejdk8
+branches:
+  only:
+  - master
+  - "/.*-[0-9]+\\..*/"
+install: true
+script: ".travis/build.sh"
+env:
+  global:
+    secure: Y+r9CrFYKvvtNXuRV5+T1EqNkVmiyZrMXAvdotqkrYg29kN/LHlc5kzCNOYVl4HLHovVjiZkr78kjgd/vl51ROK1qdzPHOqcsfKbHYzu8HhjroPAOD83TX9bZbIg3DwAJT/Poz01unyEaNF/KN9QrOY5MBTqry8XspJSPQ+8YqI28tnlaJNPmRqHLQFk7YtGQdbUt7GQnr681Kj5yTrFA0+wxnVbljcvlH/yKTQ8pq2naW/+wORCZAeqHykCBxPaVzR0c6aYBPDT7+xFtvJQuUjrgdC66C3AIXBa8OGPFeIBkOfjFX+rQmz8IqNIIGknEOfjDXeMKMBwuVtcY0voCRm/aU0pTiz5AwBW0SPK/psxVAu3YhH+kFE3/N0E10/epY94mU6ncJkmhbsMTXFZOSjcHD4ChHr/kU/2Febb++bvGaYm0C+uakUmt/qWhyDx/nm9sgiZkRGCB3hWo/6Fj8ZHMXWTBQBKyGwp0l8iTSeQvznO0zxzSnw7i/v5WtG3FtTYWFXg1RpFfqR3lAF4FMnOSorB7EeB5shJD4XTskvfZ+wAbp/jA6jk3tOs8ZumhIGHdIBdOfsxcvUf/3s1g5vQ4HjAdVwV6qHaVc4w7QkbuHwXLvoowcvaTJXBlHCLHAW+m7XzNuMVJRlKCNCXHNeRJnTevjSCdXFsp+3qTQs=

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+curl -fsLO https://raw.githubusercontent.com/scijava/scijava-scripts/master/travis-build.sh
+sh travis-build.sh

--- a/.travis/settings.xml
+++ b/.travis/settings.xml
@@ -1,0 +1,14 @@
+<settings>
+  <servers>
+    <server>
+      <id>imagej.releases</id>
+      <username>travis</username>
+      <password>${env.MAVEN_PASS}</password>
+    </server>
+    <server>
+      <id>imagej.snapshots</id>
+      <username>travis</username>
+      <password>${env.MAVEN_PASS}</password>
+    </server>
+  </servers>
+</settings>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 [![DOI](https://zenodo.org/badge/18649/thorstenwagner/ij-ridgedetection.svg)](https://zenodo.org/badge/latestdoi/18649/thorstenwagner/ij-ridgedetection)
-#Ridge Detection Plugin
-Please visit http://fiji.sc/Ridge_Detection for more information
+
+# Ridge Detection Plugin
+
+[![](https://travis-ci.org/thorstenwagner/ij-ridgedetection.svg?branch=master)](https://travis-ci.org/thorstenwagner/ij-ridgedetection)
+
+Please visit http://fiji.sc/Ridge_Detection for more information.
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,14 +6,13 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>17.0.0</version>
+		<version>17.1.1</version>
 		<relativePath />
 	</parent>
 
 	<groupId>de.biomedical-imaging.imagej</groupId>
 	<artifactId>ij_ridge_detect</artifactId>
 	<version>1.3.1-SNAPSHOT</version>
-	<packaging>jar</packaging>
 
 	<name>Ridge Detection Plugin for ImageJ</name>
 	<url>https://github.com/thorstenwagner/ij-ridgedetection</url>
@@ -59,8 +58,8 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	</issueManagement>
 
 	<ciManagement>
-		<system>Jenkins</system>
-		<url>http://jenkins.imagej.net/job/FilamentDetector/</url>
+		<system>Travis</system>
+		<url>https://travis-ci.org/thorstenwagner/ij-ridgedetection/</url>
 	</ciManagement>
 
 	<dependencies>
@@ -104,19 +103,4 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
 		</contributor>
 	</contributors>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>license-maven-plugin</artifactId>
-				<configuration>
-					<licenseName>gpl_v2</licenseName>
-					<organizationName>Thorsten Wagner (ImageJ java plugin), 1996-1998
-						Carsten Steger (original C code), 1999 R. Balasubramanian (detect
-						lines code to incorporate within GRASP)</organizationName>
-					<projectName>Ridge Detection plugin for ImageJ</projectName>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
 </project>


### PR DESCRIPTION
This PR enables Travis on this repo, automatically uploading packages to the ImageJ Maven repository.

You can also cut release versions using the release-version.sh script in scijava-scripts; see [the documentation](https://imagej.net/Development_Lifecycle#Phase_3:_Released) for details.

Supersedes and closes #29.